### PR TITLE
加上Weixin::Message的autoload

### DIFF
--- a/lib/rack-weixin.rb
+++ b/lib/rack-weixin.rb
@@ -4,7 +4,8 @@ require 'weixin/middleware'
 require 'weixin/menu'
 
 module Weixin
-
+  autoload :Message,  'weixin/model'
+  
   autoload :Music, 'weixin/model'
   autoload :Item,  'weixin/model'
 


### PR DESCRIPTION
自动加载Weixin::Message，无须在使用时再require 'weixin/model'
