### PR TITLE
使用require，更新例子

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ helpers do
         'http://nj.baidupcs.com/file/9cbb087ece3da309a31e05a7e14003c9?xcode=70d27743259294de1c42dff2d4720c05d4c19cd5e52a44f7&fid=204864837-250528-3177081425&time=1376666534&sign=FDTAXER-DCb740ccc5511e5e8fedcff06b081203-9NqxJyKhTJYx34SlHyPnK7%2B83vY%3D&to=nb&fm=B,B,T&expires=8h&rt=sh&r=756751042&logid=2171432620&sh=1&fn=%E8%BA%AB%E9%AA%91%E7%99%BD%E9%A9%AC.mp3',
         'http://nj.baidupcs.com/file/9cbb087ece3da309a31e05a7e14003c9?xcode=c59d095c8566efe4d948c3846269e02ed4c19cd5e52a44f7&fid=204864837-250528-3177081425&time=1376666631&sign=FDTAXER-DCb740ccc5511e5e8fedcff06b081203-yAO3TLeuAQ867emfUs0dYKgMtSE%3D&to=nb&fm=B,B,T&expires=8h&rt=sh&r=897038653&logid=4061975287&sh=1&fn=%E8%BA%AB%E9%AA%91%E7%99%BD%E9%A9%AC.mp3'
       )
-      Weixin.music_msg(msg.FromUserName, msg.ToUserName, mp3)
+      Weixin.music_msg(msg.ToUserName, msg.FromUserName, mp3)
     else
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '这件商品暂时缺货~~')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '这件商品暂时缺货~~')
     end
   end
 
@@ -59,29 +59,29 @@ helpers do
       'http://www.padrinorb.com/images/screens.jpg',
       'http://www.padrinorb.com/'
     )
-    Weixin.news_msg(from, to, [item])
+    Weixin.news_msg(msg.ToUserName, msg.FromUserName, [item])
   end
 
   def location_parse(msg)
     "http://maps.googleapis.com/maps/api/geocode/json?latlng=#{msg.Location_X},#{msg.Location_Y}"
-    Weixin.text_msg(msg.FromUserName, msg.ToUserName, "#{msg.Label} 周围没有妹子~")
+    Weixin.text_msg(msg.ToUserName, msg.FromUserName, "#{msg.Label} 周围没有妹子~")
   end
 
   def link_parse(msg)
     # Mechanize.new.get(msg.Url) # 爬虫
-    Weixin.text_msg(msg.FromUserName, msg.ToUserName, '这件商品暂时缺货~~')
+    Weixin.text_msg(msg.ToUserName, msg.FromUserName, '这件商品暂时缺货~~')
   end
 
   def event_parse(msg)
     case msg.Event
     when 'subscribe' # 订阅
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '欢迎订阅【数字尾巴】~~')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '欢迎订阅【数字尾巴】~~')
     when 'unsubscribe' # 退订
       # 又少了名用户
     when 'CLICK' # 点击菜单
       menu_parse(msg)
     else
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '作为一名程序猿，表示压力山大~~')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '作为一名程序猿，表示压力山大~~')
     end
   end
 
@@ -89,9 +89,9 @@ helpers do
     case msg.EventKey
     when 'profile'
       # ???
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '主人您的个人信息丢失啦~')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '主人您的个人信息丢失啦~')
     else
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '您想来点什么？')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '您想来点什么？')
     end 
   end
 
@@ -112,7 +112,7 @@ helpers do
     when 'video'
       video_parse(msg)
     else
-      Weixin.text_msg(msg.FromUserName, msg.ToUserName, '作为一名程序猿，表示压力山大~~')
+      Weixin.text_msg(msg.ToUserName, msg.FromUserName, '作为一名程序猿，表示压力山大~~')
     end
   end
 end
@@ -129,6 +129,26 @@ post '/your_app_root' do
     msg_router(message) unless message.nil?
 end
 ```
+
+### Padrino下使用
+在`Gemfile`里加入:
+
+	gem 'rack-weixin'
+
+在`config/apps.rb`关闭以下两个：
+
+	set :protection, false
+	set :protect_from_csrf, false
+	
+在`app.rb`里加入：
+
+	use Weixin::Middleware, 'your api token', '/your_app_root' 
+
+	configure do
+    	set :wx_id, 'your_weixin_account'
+	end
+
+
 
 TODO
 ----

--- a/lib/rack-weixin.rb
+++ b/lib/rack-weixin.rb
@@ -2,17 +2,10 @@
 require 'weixin/version'
 require 'weixin/middleware'
 require 'weixin/menu'
+require 'weixin/model'
 
 module Weixin
-  autoload :Message,  'weixin/model'
   
-  autoload :Music, 'weixin/model'
-  autoload :Item,  'weixin/model'
-
-  autoload :TextReplyMessage,  'weixin/model'
-  autoload :MusicReplyMessage, 'weixin/model'
-  autoload :NewsReplyMessage,  'weixin/model'
-
   extend self
 
   def music(title, desc, music_url, hq_music_url)

--- a/lib/rack-weixin.rb
+++ b/lib/rack-weixin.rb
@@ -26,7 +26,7 @@ module Weixin
     item
   end
 
-  def text_msg(from, to, content, flag=0)
+  def text_msg(from, to, content)
     msg = TextReplyMessage.new
     msg.ToUserName   = to
     msg.FromUserName = from

--- a/lib/weixin/model.rb
+++ b/lib/weixin/model.rb
@@ -166,7 +166,6 @@ module Weixin
         xml_accessor :FromUserName, :cdata => true
         xml_reader :CreateTime, :as => Integer
         xml_reader :MsgType, :cdata => true
-        xml_accessor :FuncFlag, :as => Integer
 
         def initialize
             @CreateTime = Time.now.to_i

--- a/lib/weixin/model.rb
+++ b/lib/weixin/model.rb
@@ -169,7 +169,6 @@ module Weixin
 
         def initialize
             @CreateTime = Time.now.to_i
-            @FuncFlag = 0
         end
 
         def to_xml

--- a/lib/weixin/version.rb
+++ b/lib/weixin/version.rb
@@ -1,3 +1,3 @@
 module Weixin
-  VERSION = "0.0.4.1"
+  VERSION = "0.0.4.2"
 end


### PR DESCRIPTION
因为autoload不是thread safe的，在此情况下使用会出现 `uninitialized constant Weixin::Message`错误。另外由于autoload设计有缺陷，ruby以后的版本将会移除这个功能，所以还是用`require`合理一点。

README的例子里，那个from和to搞反了，已经修正。
